### PR TITLE
Support Mac and Linux save path loading

### DIFF
--- a/spwn-lang/src/main.rs
+++ b/spwn-lang/src/main.rs
@@ -21,8 +21,19 @@ fn main() {
     // for statement in statements.iter() {
     //     println!("{:?}\n\n", statement);
     // }
-    let gd_path = PathBuf::from(std::env::var("localappdata").expect("No local app data"))
-        .join("GeometryDash/CCLocalLevels.dat");
+    let gd_path = if cfg!(target_os = "windows") {
+        PathBuf::from(std::env::var("localappdata").expect("No local app data"))
+            .join("GeometryDash/CCLocalLevels.dat")
+    } else if cfg!(target_os = "macos") {
+        PathBuf::from(std::env::var("HOME").expect("No home directory"))
+            .join("Library/Application Support/GeometryDash/CCLocalLevels.dat")
+    } else if cfg!(target_os = "linux") {
+        PathBuf::from(std::env::var("HOME").expect("No home directory"))
+            .join(".steam/steam/steamapps/compatdata/322170/pfx/drive_c/users/steamuser/Local Settings/Application Data/GeometryDash/CCLocalLevels.dat")
+    } else {
+        panic!("Unsupported operating system");
+    };
+
     let (mut compiled, old_ls) =
         compiler::compile_spwn(statements, script_path, gd_path.clone(), notes);
     let level_string = levelstring::serialize_triggers(compiled.func_ids);


### PR DESCRIPTION
hello my first time writing a PR aaaaa

Added `cfg!` options to access CCLocalLevels.dat on MacOS and Linux. I have tested this on my Linux device so can confirm that it should work with default Steam install locations however I cannot confirm for MacOS (and i remember hearing that uses a different save encoding technique anyway so idk what's even going on there) but this path is said to be correct by a Mac user.