### PR TITLE
allow compilation on platforms without editorlive

### DIFF
--- a/spwn-lang/src/editorlive_unavailable.rs
+++ b/spwn-lang/src/editorlive_unavailable.rs
@@ -1,0 +1,3 @@
+pub fn editor_paste(message: &str) -> Result<bool, String> {
+    Err(String::from("Your device does not currently support live editing"))
+}

--- a/spwn-lang/src/main.rs
+++ b/spwn-lang/src/main.rs
@@ -13,6 +13,7 @@ mod optimize;
 
 #[cfg_attr(target_os = "macos", path = "editorlive_mac.rs")]
 #[cfg_attr(windows, path = "editorlive_win.rs")]
+#[cfg_attr(not(any(target_os = "macos", windows)), path = "editorlive_unavailable.rs")]
 mod editorlive;
 
 use optimize::optimize;


### PR DESCRIPTION
been a while but another small linux compatibility suggestion.
compilation works fine otherwise but complains about not having the module `editorlive`, so this simply adds a blanket implementation for any unsupported platforms.