### PR TITLE
New data type (obj_set) and array method (.flat_map())

### DIFF
--- a/spwn-lang/libraries/std/array.spwn
+++ b/spwn-lang/libraries/std/array.spwn
@@ -162,4 +162,33 @@ impl @array {
         self = res
         return value
     }
+
+    _plus_: (self, arr: @array) {
+        return self.add(arr)
+    }
+
+    add: #[desc("Allows you to do arithmetic on two arrays")]
+    (self, arra: @array) {
+        let size1 = self.length;
+        let size2 = arra.length;
+        let out = [];
+
+        if self.all(elem => elem.type != @number) || arra.all(elem => elem.type != @number) {
+            throw "Unsupported type while adding arrays " + self as @string + " and " + arra as @string
+        }
+
+        if size1 >= size2 {
+            for i in 0..size1 {
+                if i > size2 { break }
+                out.push(self[i] + arra[i]);
+            }
+            return out;
+        } else {
+            for i in 0..size1 {
+                if i > size1 { break }
+                out.push(self[i] + arra[i]);
+            }
+            return out;
+        }
+    }
 }

--- a/spwn-lang/libraries/std/array.spwn
+++ b/spwn-lang/libraries/std/array.spwn
@@ -162,12 +162,12 @@ impl @array {
         self = res
         return value
     },
-    flat_map: #[desc("Works the same way as map but flattens any sub-arrays into one big array")]
+    flat_map: #[desc("Works the same way as map but flattens any sub-arrays into one big array.")]
     (self, cb: @macro) {
         let output = [];
         for iter in self {
             if iter.type == @array {
-                iter.map(elem => output.push(cb(elem)))
+                output += iter.map(elem => cb(elem))
             } else {
                 output.push(cb(iter));
             }

--- a/spwn-lang/libraries/std/array.spwn
+++ b/spwn-lang/libraries/std/array.spwn
@@ -161,5 +161,17 @@ impl @array {
         res += self
         self = res
         return value
-    }
+    },
+    flat_map: #[desc("Works the same way as map but flattens any sub-arrays into one big array")]
+    (self, cb: @macro) {
+        let output = [];
+        for iter in self {
+            if iter.type == @array {
+                iter.map(elem => output.push(cb(elem)))
+            } else {
+                output.push(cb(iter));
+            }
+        }
+        return output;
+    },
 }

--- a/spwn-lang/libraries/std/array.spwn
+++ b/spwn-lang/libraries/std/array.spwn
@@ -162,33 +162,4 @@ impl @array {
         self = res
         return value
     }
-
-    _plus_: (self, arr: @array) {
-        return self.add(arr)
-    }
-
-    add: #[desc("Allows you to do arithmetic on two arrays")]
-    (self, arra: @array) {
-        let size1 = self.length;
-        let size2 = arra.length;
-        let out = [];
-
-        if self.all(elem => elem.type != @number) || arra.all(elem => elem.type != @number) {
-            throw "Unsupported type while adding arrays " + self as @string + " and " + arra as @string
-        }
-
-        if size1 >= size2 {
-            for i in 0..size1 {
-                if i > size2 { break }
-                out.push(self[i] + arra[i]);
-            }
-            return out;
-        } else {
-            for i in 0..size1 {
-                if i > size1 { break }
-                out.push(self[i] + arra[i]);
-            }
-            return out;
-        }
-    }
 }

--- a/spwn-lang/libraries/std/lib.spwn
+++ b/spwn-lang/libraries/std/lib.spwn
@@ -8,6 +8,7 @@ import "item.spwn"
 import "block.spwn"
 import "array.spwn"
 import "object.spwn"
+import "obj_set.spwn"
 import "dictionary.spwn"
 import "string.spwn"
 import "counter.spwn"
@@ -30,6 +31,7 @@ ctrl_flow = import "control_flow.spwn"
     on: @event::on,
     obj_props: constants.obj_props,
     open: @file::new,
+    obj_set: @obj_set::new,
 }
 
 

--- a/spwn-lang/libraries/std/obj_set.spwn
+++ b/spwn-lang/libraries/std/obj_set.spwn
@@ -26,7 +26,9 @@ impl @obj_set {
     },
     add: #[desc("Add all the objects in the set to the game")]
     (self) {
-        self.objects.map(o => o.add());
+        for object in self.objects {
+            object.add()
+        }
     },
     copy: #[desc("Create a copy of all the objects in this set as a new set")]
     (self) {

--- a/spwn-lang/libraries/std/obj_set.spwn
+++ b/spwn-lang/libraries/std/obj_set.spwn
@@ -1,0 +1,45 @@
+#[no_std]
+extract import "constants.spwn"
+type @obj_set
+
+impl @obj_set {
+    new: #[desc("Create a new object set")]
+    (
+        objects: @array, 
+        #[desc("The group to use for rotation (?)")] group: @group = ?g
+    ) {
+        if objects.any(elem => elem.type != @object) {
+            throw "Unsupported type while creating obj_set" 
+        }
+
+        return {
+            type: @obj_set,
+            objects: objects,
+            group: group,
+        }
+    },
+    // ! The append builtin is broken at the moment, mutability is not preserved 
+    push: #[desc("Add new objects to the set")]
+    (self, object: @object) {
+        let to_push = object;
+        $.append(self.objects, to_push)
+    },
+    add: #[desc("Add all the objects in the set to the game")]
+    (self) {
+        self.objects.map(o => o.add());
+    },
+    copy: #[desc("Create a copy of all the objects in this set as a new set")]
+    (self) {
+        return self;
+    },
+    rotate: #[desc("Applies a single rotation value to all of the objects in this set")]
+    (self, deg: @number) {
+        for i in ..self.objects.length {
+            self.objects[i].set(obj_props.ROTATION, deg)
+        }
+    },
+    rotate_relative: #[desc("Rotates objects in a set around a centerpoint")]
+    (self, center_group: @group, deg: @number, duration: @number, easing: @easing_type, easing_rate: @number, lock_object_rotation: @bool) {
+        self.group.rotate(center_group, deg, duration, easing, easing_rate, lock_object_rotation)
+    }
+}


### PR DESCRIPTION
# `obj_set`

## Methods
|name|arguments|description|
|---|---|---|
| push | `self`, `obj: @object` | Add new objects to the set |
| add | `self` | Add all the objects in a set to the game |
| copy | `self` | Create a copy of all the objects in this set as a new set |
| rotate | `self`, `deg: @number` | Applies a single rotation value to all of the objects in this set|
| rotate_relative | `self`, `center_group: @group`, `deg: @number`, `duration: @number`, `easing: @easing_type`, `easing_rate: @number`, `lock_object_rotation: @bool` | Rotates objects in a set around a center point |

# Array

## Array.flat_map(...)

|name|arguments|description|
|---|---|---|
|flat_map|`self`, `cb: @macro`|Works the same way as map but flattens any sub-arrays into one big array|