### PR TITLE
Regex in spwn!!

### DIFF
--- a/spwn-lang/Cargo.lock
+++ b/spwn-lang/Cargo.lock
@@ -40,6 +40,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "base64"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -163,9 +172,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.3.4"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
+checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
 
 [[package]]
 name = "named_pipe"
@@ -210,10 +219,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex-syntax"
-version = "0.6.22"
+name = "regex"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5eb417147ba9860a96cfe72a0b93bf88fee1744b5636ec99ab20c1aa9376581"
+checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
 name = "rle-decode-fast"
@@ -242,6 +262,7 @@ dependencies = [
  "logos",
  "named_pipe",
  "quick-xml",
+ "regex",
  "smallvec",
  "termcolor",
  "text_io",

--- a/spwn-lang/Cargo.toml
+++ b/spwn-lang/Cargo.toml
@@ -16,6 +16,7 @@ logos = "0.11.4"
 termcolor = "1.1.2"
 smallvec = "1.4.2"
 text_io = "0.1.8"
+regex = "1.5.4"
 
 aes = "0.6.0"
 block-modes = "0.7.0"

--- a/spwn-lang/libraries/std/lib.spwn
+++ b/spwn-lang/libraries/std/lib.spwn
@@ -13,6 +13,7 @@ import "dictionary.spwn"
 import "string.spwn"
 import "counter.spwn"
 import "fileio.spwn"
+import "regex.spwn"
 
 general = import "general_triggers.spwn"
 events = import "events.spwn"
@@ -32,6 +33,7 @@ ctrl_flow = import "control_flow.spwn"
     obj_props: constants.obj_props,
     open: @file::new,
     obj_set: @obj_set::new,
+    regex: @regex::new
 }
 
 

--- a/spwn-lang/libraries/std/regex.spwn
+++ b/spwn-lang/libraries/std/regex.spwn
@@ -1,0 +1,21 @@
+#[no_std]
+type @regex
+
+impl @regex {
+    new: #[desc("Create a new instance of regex")]
+    (#[desc("A regex string. Make sure to use two backslashes to escape selectors instead of one or it will error")] re: @string) {
+        return {
+            type: @regex,
+            regex: re
+        }
+    },
+    match: #[desc("Checks if the regex matches a string argument")]
+    (self, match: @string) {
+        return $.regex(self.regex, match, "match", null)
+    },
+    replace: #[desc("Regex replace the contents of a string")]
+    (self, to_replace: @string, replacer: @string) {
+        let t_rep = to_replace;
+        return $.regex(self.regex, t_rep, "replace", replacer)
+    }
+}


### PR DESCRIPTION
# Regex

## Builtin

|name|arguments|returns|description|
|---|---|---|---|
|regex|`regex: @string`, `target: @string`, `operation_type: "match" \| "replace"`, `replacement: @string \| Null`|`@bool` \| `@string`|A somewhat messy regex builtin|

## Stdlib

|name|arguments|returns|description|
|---|---|---|---|
|new|`re: @string`|`Self`|Create a new instance of regex (regex selectors need to be escaped with two backslashes)|
|match|`self`, `match: @string`|`@bool`|Standard regex match|
|replace|`self`, `to_replace: @string`, `replacer: @string`|`@string`|Standard regex replace (left hand string is replaced with right hand string)|