### PR TITLE
cleaning up array.spwn

### DIFF
--- a/spwn-lang/libraries/std/array.spwn
+++ b/spwn-lang/libraries/std/array.spwn
@@ -180,13 +180,6 @@ $.assert(arr.sum() == 15)
     (self) {
         return self.reduce((acum, el) => acum + el)
     },
-    copy: #[desc("Returns a shallow copy of the array") example("
-arr = [5, 6, 7]
-assert(arr == arr.copy())
-    ")]
-    (self) {
-        return self.map(x => x)
-    },
 
     _partition: #[desc("Private function needed for .sort()")]
     (self, low: @number, high: @number, key: @macro = (a, b) => a <= b) {
@@ -217,7 +210,7 @@ arr = [5, 1, 5, 3, 2]
 arr.sort(key = (a, b) => a > b)
 $.assert(arr == [5, 5, 3, 2, 1])
     ")]
-    (self, begin: @number = 0, end: @number = -1, key: @macro = (a, b) => a <= b, ) {
+    (self, begin: @number = 0, end: @number = -1, key: @macro = (a, b) => a <= b) {
 
         // when end == -1, that means the end of the array, but comparing to -1 doesnt work so switch it back to legnth - 1
         let new_end = end
@@ -243,7 +236,7 @@ $.assert(arr.sorted(begin = 2, end = 4) == [5, 1, 2, 3, 5])
 $.assert(arr.sorted(key = (a, b) => a >= b) == [5, 5, 3, 2, 1])
     ")]
     (self) {
-        let new_arr = self.copy()
+        let new_arr = self
         new_arr.sort()
 
         return new_arr

--- a/spwn-lang/libraries/std/array.spwn
+++ b/spwn-lang/libraries/std/array.spwn
@@ -180,34 +180,6 @@ $.assert(arr.sum() == 15)
     (self) {
         return self.reduce((acum, el) => acum + el)
     },
-    sort: #[desc("Returns a sorted version of the array.") example("
-arr = [5, 1, 5, 3, 2]
-$.assert(arr.sort() == [1, 2, 3, 5, 5])
-    ")]
-    (self) {
-        // uses selection sort
-        if self.all(item => item.type == @number) {
-            min = (array, maxval = 999999999999) {
-                let lowest = [maxval, 0]
-                for i in 0..array.length {
-                    if array[i] < lowest[0] {
-                        lowest = [array[i], i]
-                    }
-                }
-                return lowest
-            }
-            let res = []
-            let copy = self
-            for i in self {
-                i = min(copy)
-                res.push(i[0])
-                copy.remove(i[1])
-            }
-            return res
-        } else {
-            throw "Unsupported type in array " + self as @string
-        }
-    },
     copy: #[desc("Returns a shallow copy of the array") example("
 arr = [5, 6, 7]
 assert(arr == arr.copy())


### PR DESCRIPTION
- removed `copy` because redundant
- removed the original sort method