### PR TITLE
lol added `enumerate` 

### DIFF
--- a/spwn-lang/libraries/std/array.spwn
+++ b/spwn-lang/libraries/std/array.spwn
@@ -285,5 +285,20 @@ $.assert(arr.flatten() == [1, 2, 3, 4, 5, 6, 7, 8])
         }
 
         return output
+    },
+    enumerate: #[desc("Returns an array of dictionaries that store pairs of index and value" example("
+arr = [5,6,7,4,3]
+$.assert(arr.enumerate() == [{v: 5,k: 0},{k: 1,v: 6},{v: 7,k: 2},{v: 4,k: 3},{v: 3,k: 4}])
+    "))]
+    (self) {
+        let ret = []
+        for i in ..self.length {
+            ret.push({
+                k: i,
+                v: self[i] 
+            })
+        }
+
+        return ret
     }
 }


### PR DESCRIPTION
normally this pairs well when a language has destructuring but this declarative syntax is still clean and very nice

example as such

```spwn
let arr = [5,4,6,4]

for p in arr.enumerate() {
  // you can keep this as p without defining
  k = p.k
  v = p.v

  /* code */
}
```

if you don't merge this I like totally understand this is bordering on not needed but hey idk