### PR TITLE
Fix Arch/Debian path mistake.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ You can either use the installers for your operating system, or build SPWN from 
 deb@spwn:~$ sudo dpkg -i spwn_0.0.5-0_amd64.deb
 ```
 
-- Install the arch package using pacman and add `/usr/local/bin` to path:
+- Install the arch package using pacman and add `/usr/local/bin/spwn` to path:
 ```sh
 [arch@spwn ~$] pacman -U spwn-0.0.5-0_amd64.pkg.tar.zst
-[arch@spwn ~$] echo 'export PATH="/usr/local/bin:$PATH"' >> ~/.bashrc
+[arch@spwn ~$] echo 'export PATH="/usr/local/bin/spwn:$PATH"' >> ~/.bashrc
 ```
 
 ###### Compiling from source


### PR DESCRIPTION
I confused Spu7nix

Quick edit: I just realized I didn't need the Debian part, it was just Arch.