### PR TITLE
Add raw strings

### DIFF
--- a/libraries/std/string.spwn
+++ b/libraries/std/string.spwn
@@ -1,4 +1,5 @@
 #[no_std, cache_output]
+
 impl @string {
 	is_empty: #[desc("Returns true if the string has a length of 0, false otherwise")]
 	(self) {
@@ -152,8 +153,8 @@ $.assert('hi {1} and {0}'.fmt([name1, name2]) == 'hi alice and bob')
 $.assert('{} has {} apples'.fmt([name1, 5]) == 'bob has 5 apples')
     ")]
     (self, subs) {
-        blank_regex = "\\{\\}"
-        numbered_regex = "\\{\\d+\\}"
+        blank_regex = r"\{\}"
+        numbered_regex = r"\{\d+\}"
 
         blanks = $.regex(blank_regex, self, 'findall', null)
         numbered = $.regex(numbered_regex, self, 'findall', null)
@@ -194,5 +195,17 @@ $.assert('{} has {} apples'.fmt([name1, 5]) == 'bob has 5 apples')
         }
 
         return ret_str
+    },
+
+    find: (self, re: @string) {
+        $.regex(re, self, "match", null)
+    },
+
+    findall: (self, re: @string) {
+        $.regex(re, self, "findall", null)
+    },
+
+    replace: (self, re: @string, replacement: @string) {
+        $.regex(re, self, "replace", replacement)
     }
 }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -66,7 +66,7 @@ pub enum ValueBody {
     Symbol(Intern<String>),
     Bool(bool),
     Expression(Expression),
-    Str(String),
+    Str(StrInner),
     Import(ImportType, bool),
     Switch(Expression, Vec<Case>),
     Array(Vec<Expression>),
@@ -103,6 +103,17 @@ pub enum ObjectMode {
 pub struct ObjectLiteral {
     pub props: Vec<(Expression, Expression)>,
     pub mode: ObjectMode,
+}
+
+#[derive(Clone, PartialEq, Debug)]
+pub struct StrInner {
+    pub inner: String,
+    pub flags: Option<StringFlags>
+}
+
+#[derive(Clone, PartialEq, Debug)]
+pub enum StringFlags {
+    Raw
 }
 
 #[derive(Clone, Copy, PartialEq, Debug)]
@@ -183,7 +194,7 @@ impl Attribute {
                     None
                 } else {
                     match &args[0].value.values[0].value.body {
-                        ValueBody::Str(s) => Some(s.clone()),
+                        ValueBody::Str(s) => Some(s.inner.clone()),
                         a => Some(a.fmt(0)),
                     }
                 }
@@ -199,7 +210,7 @@ impl Attribute {
                 None
             } else {
                 match &args[0].value.values[0].value.body {
-                    ValueBody::Str(s) => Some(s.trim().to_string()),
+                    ValueBody::Str(s) => Some(s.inner.trim().to_string()),
                     val => Some(val.fmt(0)),
                 }
             }

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -631,7 +631,7 @@ pub fn compile_scope(
                                         let ranges = var_a.iter().filter(|x| x.values[0].operator == Some(ast::UnaryOperator::Range)).collect::<Vec<&ast::Expression>>();
 
                                         if ranges.len() > 1 {
-                                            let mut why_sput = info.position.clone();
+                                            let mut why_sput = info.position;
                                             why_sput.pos = ranges[0].values[0].pos;
                                             info.position.pos = ranges[1].values[0].pos;
 
@@ -661,7 +661,7 @@ pub fn compile_scope(
                                             loop {
                                                 let mut idx_step = 1;
                                                 for expr_ctx in ctx.iter() {
-                                                    if var_a[var_idx].operators.len() > 0 || var_a[var_idx].values.len() == 0 {
+                                                    if var_a[var_idx].operators.is_empty() || var_a[var_idx].values.is_empty() {
                                                         use crate::fmt::_format2;
 
                                                         return Err(RuntimeError::CustomError(create_error(
@@ -1027,9 +1027,9 @@ pub fn compile_scope(
                         GdObj {
                             params,
 
-                            ..context_trigger(&context, &mut globals.uid_counter)
+                            ..context_trigger(context, &mut globals.uid_counter)
                         }
-                        .context_parameters(&context),
+                        .context_parameters(context),
                         globals.trigger_order,
                     ))
                 }

--- a/src/documentation.rs
+++ b/src/documentation.rs
@@ -105,7 +105,7 @@ pub fn document_lib(path: &str) -> Result<(), RuntimeError> {
                 (
                     key,
                     val.iter()
-                        .map(|(key, val)| (key.clone(), val.0))
+                        .map(|(key, val)| (*key, val.0))
                         .collect::<HashMap<Intern<String>, StoredValue>>(),
                 )
             })

--- a/src/editorlive_unavailable.rs
+++ b/src/editorlive_unavailable.rs
@@ -1,3 +1,3 @@
-pub fn editor_paste(message: &str) -> Result<bool, String> {
+pub fn editor_paste(_: &str) -> Result<bool, String> {
     Err(String::from("Your device does not currently support live editing"))
 }

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -25,13 +25,13 @@ fn tabs(mut num: Indent) -> String {
 pub fn _format(input: Vec<Statement>) -> String {
     let mut out = String::new();
     for s in input {
-        out += &s.fmt(0).to_string();
+        out += &s.fmt(0)
     }
     out
 }
 
 pub fn _format2(input: &ValueBody) -> String {
-    input.fmt(0).to_string()
+    input.fmt(0)
 }
 
 fn element_list(elements: &[impl SpwnFmt], open: char, closing: char, ind: Indent) -> String {
@@ -259,7 +259,7 @@ impl SpwnFmt for ValueBody {
             Symbol(x) => x.to_string(),
             Bool(x) => format!("{}", x),
             Expression(x) => format!("({})", x.fmt(ind)),
-            Str(x) => format!("\"{}\"", x),
+            Str(x) => format!("\"{}\"", x.inner),
             Import(x, f) => format!("import{} {:?}", if *f { "!" } else { "" }, x),
             Obj(x) => {
                 (match x.mode {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3,6 +3,7 @@ use crate::ast;
 use pest::Parser;
 use pest_derive::Parser;*/
 
+use crate::ast::StrInner;
 use crate::builtin::Builtin;
 
 use crate::compiler::ErrorReport;
@@ -2023,7 +2024,9 @@ fn parse_variable(
         }),
         Some(Token::StringLiteral) => {
             // is a string
-            ast::ValueBody::Str(str_content(tokens.slice(), tokens, notes)?)
+            let content = str_content(tokens.slice(), tokens, notes)?;
+            let inner = StrInner { inner: content, flags: None };
+            ast::ValueBody::Str(inner)
         }
         Some(Token::Id) => {
             let mut text = tokens.slice();

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -4,6 +4,7 @@ use pest::Parser;
 use pest_derive::Parser;*/
 
 use crate::ast::StrInner;
+use crate::ast::StringFlags;
 use crate::builtin::Builtin;
 
 use crate::compiler::ErrorReport;
@@ -254,7 +255,7 @@ pub enum Token {
     #[regex(r"[0-9]+(\.[0-9]+)?")]
     Number,
 
-    #[regex(r#""(?:\\.|[^\\"])*"|'(?:\\.|[^\\'])*'"#)]
+    #[regex(r#"[a-z]?"(?:\\.|[^\\"])*"|'(?:\\.|[^\\'])*'"#)]
     StringLiteral,
 
     #[token("true")]
@@ -1628,8 +1629,8 @@ fn parse_arg_def(
             Some(Token::Ampersand) => {
                 arg_tok = tokens.next(false);
                 true
-            },
-            _ => false
+            }
+            _ => false,
         };
 
         let symbol = Intern::new(tokens.slice());
@@ -1697,17 +1698,15 @@ fn parse_arg_def(
                 }
 
                 match arg_tok {
-                    Some(Token::Symbol) | Some(Token::SelfVal) => {
-                        (
-                            symbol,
-                            None,
-                            properties,
-                            None,
-                            (start, tokens.position().1),
-                            as_ref
-                        )
-                    },
-                    _ => expected!("symbol".to_string(), tokens, notes, arg_tok)
+                    Some(Token::Symbol) | Some(Token::SelfVal) => (
+                        symbol,
+                        None,
+                        properties,
+                        None,
+                        (start, tokens.position().1),
+                        as_ref,
+                    ),
+                    _ => expected!("symbol".to_string(), tokens, notes, arg_tok),
                 }
             }
             None => {
@@ -1800,33 +1799,55 @@ pub fn str_content(
     mut inp: String,
     tokens: &Tokens,
     notes: &ParseNotes,
-) -> Result<String, SyntaxError> {
-    inp.remove(0);
+) -> Result<(String, Option<StringFlags>), SyntaxError> {
+    let first = inp.remove(0);
     inp.remove(inp.len() - 1);
-    let mut out = String::new();
+
+    let mut out = (String::new(), None);
     let mut chars = inp.chars();
 
-    while let Some(c) = chars.next() {
-        out.push(if c == '\\' {
-            match chars.next() {
-                Some('n') => '\n',
-                Some('r') => '\r',
-                Some('t') => '\t',
-                Some('"') => '\"',
-                Some('\'') => '\'',
-                Some('\\') => '\\',
-                Some(a) => {
-                    return Err(SyntaxError::SyntaxError {
-                        message: format!("Invalid escape: \\{}", a),
-                        pos: tokens.position(),
-                        file: notes.file.clone(),
-                    })
-                }
-                None => unreachable!(),
+    match first {
+        '\'' | '"' => {
+            while let Some(c) = chars.next() {
+                out.0.push(if c == '\\' {
+                    match chars.next() {
+                        Some('n') => '\n',
+                        Some('r') => '\r',
+                        Some('t') => '\t',
+                        Some('"') => '\"',
+                        Some('\'') => '\'',
+                        Some('\\') => '\\',
+                        Some(a) => {
+                            return Err(SyntaxError::SyntaxError {
+                                message: format!("Invalid escape: \\{}", a),
+                                pos: tokens.position(),
+                                file: notes.file.clone(),
+                            })
+                        }
+                        None => unreachable!(),
+                    }
+                } else {
+                    c
+                });
             }
-        } else {
-            c
-        });
+        }
+        'r' => {
+            // remove "
+            chars.next();
+
+            out.1 = StringFlags::Raw.into();
+
+            while let Some(c) = chars.next() {
+                out.0.push(c);
+            }
+        }
+        _ => {
+            return Err(SyntaxError::SyntaxError {
+                file: notes.file.to_owned(),
+                pos: tokens.position(),
+                message: format!("Invalid string flag: {}", first),
+            })
+        }
     }
 
     Ok(out)
@@ -2024,8 +2045,12 @@ fn parse_variable(
         }),
         Some(Token::StringLiteral) => {
             // is a string
-            let content = str_content(tokens.slice(), tokens, notes)?;
-            let inner = StrInner { inner: content, flags: None };
+
+            let (content, flag) = str_content(tokens.slice(), tokens, notes)?;
+            let inner = StrInner {
+                inner: content,
+                flags: flag.into(),
+            };
             ast::ValueBody::Str(inner)
         }
         Some(Token::Id) => {
@@ -2074,7 +2099,14 @@ fn parse_variable(
                     // Woo macro shorthand
                     let arg = if symbol.as_ref() != "_" {
                         is_valid_symbol(&symbol, tokens, notes)?;
-                        vec![(symbol, None, properties.clone(), None, tokens.position(), false)]
+                        vec![(
+                            symbol,
+                            None,
+                            properties.clone(),
+                            None,
+                            tokens.position(),
+                            false,
+                        )]
                     } else {
                         Vec::new()
                     };
@@ -2193,7 +2225,12 @@ fn parse_variable(
                             match tokens.next(false) {
                                 Some(Token::For) => {
                                     if arr.len() > 0 {
-                                        expected!("comma (',') or ']'".to_string(), tokens, notes, Some(Token::For));
+                                        expected!(
+                                            "comma (',') or ']'".to_string(),
+                                            tokens,
+                                            notes,
+                                            Some(Token::For)
+                                        );
                                     }
 
                                     match tokens.next(false) {
@@ -2202,41 +2239,59 @@ fn parse_variable(
 
                                             match tokens.next(false) {
                                                 Some(Token::In) => (),
-                                                a => expected!("'in'".to_string(), tokens, notes, a),
+                                                a => {
+                                                    expected!("'in'".to_string(), tokens, notes, a)
+                                                }
                                             }
 
                                             let iter = parse_expr(tokens, notes, true, true)?;
 
-                                            let mut potential_condition: Option<ast::Expression> = None;
+                                            let mut potential_condition: Option<ast::Expression> =
+                                                None;
 
                                             match tokens.next(false) {
                                                 Some(Token::ClosingSquareBracket) => (),
-                                                Some(Token::Comma) => {
-                                                    match tokens.next(false) {
-                                                        Some(Token::If) => {
-                                                            potential_condition = Some(parse_expr(tokens, notes, true, true)?);
-                                                            match tokens.next(false) {
-                                                                Some(Token::ClosingSquareBracket) => (),
-                                                                a => expected!("]".to_string(), tokens, notes, a)
-                                                            }
-                                                        },
-                                                        a => expected!("if".to_string(), tokens, notes, a)
+                                                Some(Token::Comma) => match tokens.next(false) {
+                                                    Some(Token::If) => {
+                                                        potential_condition = Some(parse_expr(
+                                                            tokens, notes, true, true,
+                                                        )?);
+                                                        match tokens.next(false) {
+                                                            Some(Token::ClosingSquareBracket) => (),
+                                                            a => expected!(
+                                                                "]".to_string(),
+                                                                tokens,
+                                                                notes,
+                                                                a
+                                                            ),
+                                                        }
                                                     }
+                                                    a => expected!(
+                                                        "if".to_string(),
+                                                        tokens,
+                                                        notes,
+                                                        a
+                                                    ),
                                                 },
-                                                a => expected!("']' or ','".to_string(), tokens, notes, a),
+                                                a => expected!(
+                                                    "']' or ','".to_string(),
+                                                    tokens,
+                                                    notes,
+                                                    a
+                                                ),
                                             }
 
                                             potential_listcomp = Some(ast::Comprehension {
                                                 body: item,
                                                 symbol: Intern::new(tok_name),
                                                 iterator: iter,
-                                                condition: potential_condition
+                                                condition: potential_condition,
                                             });
                                             break;
-                                        },
-                                        a => expected!("identifier".to_string(), tokens, notes, a)
+                                        }
+                                        a => expected!("identifier".to_string(), tokens, notes, a),
                                     }
-                                },
+                                }
                                 Some(Token::Comma) => {
                                     //accounting for trailing comma
                                     arr.push(item);
@@ -2249,8 +2304,13 @@ fn parse_variable(
                                 Some(Token::ClosingSquareBracket) => {
                                     arr.push(item);
                                     break;
-                                },
-                                a => expected!("comma (','), ']', or 'for'".to_string(), tokens, notes, a),
+                                }
+                                a => expected!(
+                                    "comma (','), ']', or 'for'".to_string(),
+                                    tokens,
+                                    notes,
+                                    a
+                                ),
                             }
                         }
                     }
@@ -2271,10 +2331,24 @@ fn parse_variable(
                 first = tokens.next(false);
             }
             match first {
-                Some(Token::StringLiteral) => ast::ValueBody::Import(
-                    ImportType::Script(PathBuf::from(str_content(tokens.slice(), tokens, notes)?)),
-                    forced,
-                ),
+                Some(Token::StringLiteral) => {
+                    let (content, flag) = str_content(tokens.slice(), tokens, notes)?;
+
+                    if flag.is_some() {
+                        return Err(SyntaxError::UnexpectedErr {
+                            file: notes.file.to_owned(),
+                            pos: tokens.position(),
+                            found: format!("string flag ({:?})", flag),
+                        })
+                    }
+
+                    ast::ValueBody::Import(
+                        ImportType::Script(PathBuf::from(
+                            content,
+                        )),
+                        forced,
+                    )
+                }
                 Some(Token::Symbol) => {
                     ast::ValueBody::Import(ImportType::Lib(tokens.slice()), forced)
                 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -810,7 +810,7 @@ impl ast::Variable {
                     }
                 }
                 ast::ValueBody::Str(s) => full_context.inner().return_value = store_const_value(
-                        Value::Str(s.clone()),
+                        Value::Str(s.inner.clone()),
                         
                         globals,
                         full_context.inner().start_group,
@@ -2388,7 +2388,7 @@ impl ast::Variable {
                     if i.values.len() == 1 {
                         if let ast::ValueBody::Str(s) = &i.values[0].value.body {
                             match &globals.stored_values[current_ptr] {
-                                Value::Dict(d) => return d.get(s).is_some(),
+                                Value::Dict(d) => return d.get(&s.inner).is_some(),
                                 _ => return true,
                             }
                         } else {

--- a/test/test.spwn
+++ b/test/test.spwn
@@ -1,3 +1,6 @@
-let a = complex(3,4)
+let reg = r"\w"; // raw string, ignores any escapes (TODO: add regex rule for spwn.vim and the spwn vscode ext)
+let str = "hewwo";
 
-$.print(a.sqrt())
+$.print(str.find(reg)) //=> true
+$.print(str.findall(reg)) //=> [[0,1],[1,2],[2,3],[3,4],[4,5]]
+$.print(str.replace(reg, "byebye")) //=> byebye


### PR DESCRIPTION
# Raw strings

Raw strings in SPWN do not do anything with escapes

### Examples

```rs
let reg = r"\w"; // Will not throw an "invalid escape" error
let string = "hewwo";

$.print(string.find(reg)) //=> true
$.print(string.findall(reg)) //=> [[0,1],[1,2],[2,3],[3,4],[4,5]]
$.print(string.replace(reg, "byebye")) //=> byebye
```