### PR TITLE
revised `.pop` and `.remove`

### DIFF
--- a/libraries/std/array.spwn
+++ b/libraries/std/array.spwn
@@ -122,21 +122,24 @@ $.assert(arr == [1, 2, 3, 4])
     (self, value) {
         $.append(self, value)
     },
-    pop: #[desc("Removes the last value from the array and returns it.") example("
+    pop: #[desc("Removes a specific index from the array and returns it.") example("
 let arr = [1, 2, 3, 4]
 arr.pop()
 $.assert(arr == [1, 2, 3])
+arr.pop(1)
+$.assert(arr == [1, 3])
     ")]
-    (self) {
-        return $.pop(self)
+    (self, index: @number = -1) {
+        index = index if index >= 0 else self.length + index // to correct for negative values
+        return $.remove_index(self, index)
     },
-    remove: #[desc("Removes a specific index from the array and returns it.") example("
+    remove: #[desc("Returns array with all elements that match value removed") example("
 let arr = [1, 2, 3, 4, 5]
 arr.remove(3)
-$.assert(arr == [1, 2, 3, 5])
+$.assert(arr == [1, 2, 4, 5])
     ")]
     (self, index: @number) {
-        return $.remove_index(self, index)
+        return self.map(x => x if x != index else null).filter(el => el != null)
     },
     map: #[desc("Calls a defined callback function on each element of an array, and returns an array that contains the results.") example("
 arr = [1, 2, 3, 4, 5]


### PR DESCRIPTION
- made `.pop` accept indexes to remove
- `$.pop` is broken so i had to fix the fact that it dealt with negative indexes inconsistent with convention
- `.remove` returns a removed version of the array deleting by _value_, not by index