### PR TITLE
Cooler http requests

### DIFF
--- a/libraries/std/http.spwn
+++ b/libraries/std/http.spwn
@@ -2,77 +2,46 @@
 
 type @http
 impl @http {
-    _dict_to_str: (dict: @dictionary) {
-        let output = []
-        for pair in dict.items() {
-            output.push($.b64encode(pair[0]) + ":" + $.b64encode(pair[1]))
-        }
-        if output == [] {
-            return ""
-        }
-        else {
-            return ",".join(output)
-        }
-    },
-    _abstract_request: (url: @string, headers: @dictionary, method) {
-        let temp = @http::{
-            encoded: method(url, @http::_dict_to_str(headers))
-        }
-        return temp.decode()
-    },
-    _abstract_request_body: (url: @string, headers: @dictionary, body, method) {
-        let temp = @http::{
-            encoded: method(url, @http::_dict_to_str(headers), body as @string)
-        }
-        return temp.decode()
-    },
     get: #[desc("Makes a get request to the provided URL. A dictionary of headers can optionally be passed in as a second argument")]
     (url: @string, headers: @dictionary = {}, body = "") {
-        return @http::_abstract_request_body(url, headers, body, $.http_get)
+        return $.http_request(
+            "get",
+            url, headers, body
+        )
     },
     post: #[desc("Makes a post request to the provided URL. A dictionary of headers can optionally be passed in as a second argument")]
     (url: @string, headers: @dictionary = {}, body = "") {
-        return @http::_abstract_request_body(url, headers, body, $.http_post)
+        return $.http_request(
+            "post",
+            url, headers, body
+        )
     },
     put: #[desc("Makes a put request to the provided URL. A dictionary of headers can optionally be passed in as a second argument")]
     (url: @string, headers: @dictionary = {}, body = "") {
-        return @http::_abstract_request_body(url, headers, body, $.http_put)
+        return $.http_request(
+            "put",
+            url, headers, body
+        )
     },
     delete: #[desc("Makes a put request to the provided URL. A dictionary of headers can optionally be passed in as a second argument")]
     (url: @string, headers: @dictionary = {}, body = "") {
-        return @http::_abstract_request_body(url, headers, body, $.http_delete)
+        return $.http_request(
+            "delete",
+            url, headers, body
+        )
     },
     patch: #[desc("Makes a patch request to the provided URL. A dictionary of headers can optionally be passed in as a second argument")]
     (url: @string, headers: @dictionary = {}, body = "") {
-        return @http::_abstract_request_body(url, headers, body, $.http_patch)
+        return $.http_request(
+            "patch",
+            url, headers, body
+        )
     },
     head: #[desc("Makes a head request to the provided URL. A dictionary of headers can optionally be passed in as a second argument")]
     (url: @string, headers: @dictionary = {}, body = "") {
-        return @http::_abstract_request_body(url, headers, body, $.http_head)
+        return $.http_request(
+            "head",
+            url, headers, body
+        )
     },
-    _decode_headers: (headers: @string) {
-        pairs = headers.substr(1, headers.length-1).split(',')
-        let output = {}
-        for pair in pairs {
-            parts = pair.split(': ')
-            if parts != [''] {
-                key = $.b64decode(parts[0])
-                value = $.b64decode(parts[1])
-                output.set(key, value)
-            }
-        }
-        return output
-    },
-    decode: 
-    (self) {
-        parts = self.encoded.split("||")
-        status = $.b64decode(parts[0]) as @number
-        text = $.b64decode(parts[2])
-        headers = @http::_decode_headers($.b64decode(parts[1]))
-        return {
-            status,
-            text,
-            headers
-        }
-    }
 }

--- a/libraries/std/http.spwn
+++ b/libraries/std/http.spwn
@@ -14,12 +14,41 @@ impl @http {
             return ",".join(output)
         }
     },
-    get: #[desc("Makes a get request to the provided URL. A dictionary of headers can optionally be passed in as a second argument")]
-    (url: @string, headers: @dictionary = {}) {
+    _abstract_request: (url: @string, headers: @dictionary, method) {
         let temp = @http::{
-            encoded: $.http_get(url, @http::_dict_to_str(headers))
+            encoded: method(url, @http::_dict_to_str(headers))
         }
         return temp.decode()
+    },
+    _abstract_request_body: (url: @string, headers: @dictionary, body, method) {
+        let temp = @http::{
+            encoded: method(url, @http::_dict_to_str(headers), body as @string)
+        }
+        return temp.decode()
+    },
+    get: #[desc("Makes a get request to the provided URL. A dictionary of headers can optionally be passed in as a second argument")]
+    (url: @string, headers: @dictionary = {}, body = "") {
+        return @http::_abstract_request_body(url, headers, body, $.http_get)
+    },
+    post: #[desc("Makes a post request to the provided URL. A dictionary of headers can optionally be passed in as a second argument")]
+    (url: @string, headers: @dictionary = {}, body = "") {
+        return @http::_abstract_request_body(url, headers, body, $.http_post)
+    },
+    put: #[desc("Makes a put request to the provided URL. A dictionary of headers can optionally be passed in as a second argument")]
+    (url: @string, headers: @dictionary = {}, body = "") {
+        return @http::_abstract_request_body(url, headers, body, $.http_put)
+    },
+    delete: #[desc("Makes a put request to the provided URL. A dictionary of headers can optionally be passed in as a second argument")]
+    (url: @string, headers: @dictionary = {}, body = "") {
+        return @http::_abstract_request_body(url, headers, body, $.http_delete)
+    },
+    patch: #[desc("Makes a patch request to the provided URL. A dictionary of headers can optionally be passed in as a second argument")]
+    (url: @string, headers: @dictionary = {}, body = "") {
+        return @http::_abstract_request_body(url, headers, body, $.http_patch)
+    },
+    head: #[desc("Makes a head request to the provided URL. A dictionary of headers can optionally be passed in as a second argument")]
+    (url: @string, headers: @dictionary = {}, body = "") {
+        return @http::_abstract_request_body(url, headers, body, $.http_head)
     },
     _decode_headers: (headers: @string) {
         pairs = headers.substr(1, headers.length-1).split(',')

--- a/src/builtin.rs
+++ b/src/builtin.rs
@@ -636,143 +636,99 @@ builtins! {
         Value::Str(String::from_utf8_lossy(&decrypted).to_string())
     }
 
-    [HTTPPost] fn http_post((url): Str, (headers): Str, (body): Str) {
-        let client = reqwest::blocking::Client::new();
-        let request_headers = match str_into_headermap(&headers) {
-            Ok(headers) => headers,
-            Err(error) => {
-                return Err(RuntimeError::BuiltinError {
-                    message: error,
-                    info,
-                })
-            }
-        };
-        let response = match client.post(&url).headers(request_headers).body(body).send() {
-            Ok(data) => data,
-            Err(_) => {
-                return Err(RuntimeError::BuiltinError {
-                    message: format!("Could not make request to '{}'. Check the URL is valid and your internet connection is working.", url),
-                    info,
-                })
-            }
-        };
-        Value::Str(encode_http_response(response)) 
-    }
-
-    [HTTPPut] fn http_put((url): Str, (headers): Str, (body): Str) {
-        let client = reqwest::blocking::Client::new();
-        let request_headers = match str_into_headermap(&headers) {
-            Ok(headers) => headers,
-            Err(error) => {
-                return Err(RuntimeError::BuiltinError {
-                    message: error,
-                    info,
-                })
-            }
-        };
-        let response = match client.put(&url).headers(request_headers).body(body).send() {
-            Ok(data) => data,
-            Err(_) => {
-                return Err(RuntimeError::BuiltinError {
-                    message: format!("Could not make request to '{}'. Check the URL is valid and your internet connection is working.", url),
-                    info,
-                })
-            }
-        };
-        Value::Str(encode_http_response(response)) 
-    }
-
-    [HTTPDelete] fn http_delete((url): Str, (headers): Str, (body): Str) {
-        let client = reqwest::blocking::Client::new();
-        let request_headers = match str_into_headermap(&headers) {
-            Ok(headers) => headers,
-            Err(error) => {
-                return Err(RuntimeError::BuiltinError {
-                    message: error,
-                    info,
-                })
-            }
-        };
-        let response = match client.delete(&url).headers(request_headers).body(body).send() {
-            Ok(data) => data,
-            Err(_) => {
-                return Err(RuntimeError::BuiltinError {
-                    message: format!("Could not make request to '{}'. Check the URL is valid and your internet connection is working.", url),
-                    info,
-                })
-            }
-        };
-        Value::Str(encode_http_response(response)) 
-    }
-
-    [HTTPHead] fn http_head((url): Str, (headers): Str, (body): Str) {
-        let client = reqwest::blocking::Client::new();
-        let request_headers = match str_into_headermap(&headers) {
-            Ok(headers) => headers,
-            Err(error) => {
-                return Err(RuntimeError::BuiltinError {
-                    message: error,
-                    info,
-                })
-            }
-        };
-        let response = match client.head(&url).headers(request_headers).body(body).send() {
-            Ok(data) => data,
-            Err(_) => {
-                return Err(RuntimeError::BuiltinError {
-                    message: format!("Could not make request to '{}'. Check the URL is valid and your internet connection is working.", url),
-                    info,
-                })
-            }
-        };
-        Value::Str(encode_http_response(response)) 
-    }
 
 
-    [HTTPPatch] fn http_patch((url): Str, (headers): Str, (body): Str) {
-        let client = reqwest::blocking::Client::new();
-        let request_headers = match str_into_headermap(&headers) {
-            Ok(headers) => headers,
-            Err(error) => {
-                return Err(RuntimeError::BuiltinError {
-                    message: error,
-                    info,
-                })
-            }
-        };
-        let response = match client.patch(&url).headers(request_headers).body(body).send() {
-            Ok(data) => data,
-            Err(_) => {
-                return Err(RuntimeError::BuiltinError {
-                    message: format!("Could not make request to '{}'. Check the URL is valid and your internet connection is working.", url),
-                    info,
-                })
-            }
-        };
-        Value::Str(encode_http_response(response)) 
-    }
+    [HTTPRequest] fn http_request((method): Str, (url): Str, (headers): Dict, (body): Str) {
 
-    [HTTPGet] fn http_get((url): Str, (headers): Str, (body): Str) {
+        let mut headermap = reqwest::header::HeaderMap::new();
+        for (name, value) in &headers {
+            let header_name = match reqwest::header::HeaderName::from_bytes(name.as_bytes()) {
+                Ok(hname) => hname,
+                Err(_) => {
+                    return Err(RuntimeError::BuiltinError {
+                        message: format!("Could not convert header name: '{}'", name),
+                        info
+                    })
+                }
+            };
+            let header_value = globals.stored_values[*value].clone().to_str(globals);
+            headermap.insert(header_name, header_value.parse().unwrap());
+        }
+
         let client = reqwest::blocking::Client::new();
-        let request_headers = match str_into_headermap(&headers) {
-            Ok(headers) => headers,
-            Err(error) => {
+        let request_maker = match &method[..] {
+            "get" => client.get(&url),
+            "post" => client.post(&url),
+            "put" => {
+                client.put(&url)
+            },
+            "patch" => client.patch(&url),
+            "delete" => client.delete(&url),
+            "head" => client.head(&url),
+            _ => {
                 return Err(RuntimeError::BuiltinError {
-                    message: error,
-                    info,
+                    message: format!("Request type not supported: '{}'", method),
+                    info
                 })
             }
         };
-        let response = match client.get(&url).headers(request_headers).body(body).send() {
-            Ok(data) => data,
-            Err(_) => {
-                return Err(RuntimeError::BuiltinError {
-                    message: format!("Could not make request to '{}'. Check the URL is valid and your internet connection is working.", url),
-                    info,
-                })
-            }
+
+        let response = match request_maker
+            .headers(headermap)
+            .body(body)
+            .send() {
+                Ok(resp) => resp,
+                Err(_) => {
+                    return Err(RuntimeError::BuiltinError {
+                        message: format!("Could not make request to: '{}'", url),
+                        info
+                    })
+                }
         };
-        Value::Str(encode_http_response(response)) 
+
+        let mut output_map = HashMap::new();
+
+        let response_status = store_const_value(
+            Value::Number(
+                response.status().as_u16() as f64
+            ),
+            globals,
+            context.start_group,
+            CodeArea::new(),
+        );
+
+        let response_headermap = response.headers();
+        let mut response_headers_value = HashMap::new();
+        for (name, value) in response_headermap.iter() {
+            let header_value = store_const_value(
+                Value::Str(String::from(value.to_str().expect("Couldn't parse return header value"))),
+                globals,
+                context.start_group,
+                CodeArea::new()
+            );
+            response_headers_value.insert(Intern::new(String::from(name.as_str())), header_value);
+        }
+
+        let response_headers = store_const_value(
+            Value::Dict(response_headers_value),
+            globals,
+            context.start_group,
+            CodeArea::new()
+        );
+
+        let response_text = store_const_value(
+            Value::Str(
+                response.text().expect("Failed to parse response text")
+            ),
+            globals,
+            context.start_group,
+            CodeArea::new(),
+        );
+
+        output_map.insert(Intern::new(String::from("status")), response_status);
+        output_map.insert(Intern::new(String::from("headers")), response_headers);
+        output_map.insert(Intern::new(String::from("text")), response_text);
+        Value::Dict(output_map)
     }
 
     [Sin] fn sin((n): Number) { Value::Number(n.sin()) }

--- a/test.spwn
+++ b/test.spwn
@@ -1,0 +1,2 @@
+test = @http::get("https://httpbin.org/get")
+$.print(test)

--- a/test.spwn
+++ b/test.spwn
@@ -1,2 +1,0 @@
-test = @http::get("https://httpbin.org/get")
-$.print(test)


### PR DESCRIPTION
basically a re-write of the old http requests to not use weird b63 encoding stuff. If you used the `@http` type before then the usage is the same. new `$.http_request` method has replaced all the old methods `(http_get, http_post, ...)` and takes in method as first parameter. e.g.:
```
$.http_request(
    "get",
    url, headers, body
)
```