### PR TITLE
quick fix for broken header parsing

### DIFF
--- a/src/builtin.rs
+++ b/src/builtin.rs
@@ -732,7 +732,7 @@ builtins! {
                 }
             };
             let header_value = globals.stored_values[*value].clone().to_str(globals);
-            headermap.insert(header_name, header_value.parse().unwrap());
+            headermap.insert(header_name, header_value.trim_matches('\'').parse().unwrap());
         }
 
         let client = reqwest::blocking::Client::new();

--- a/test.spwn
+++ b/test.spwn
@@ -1,2 +1,0 @@
-let request = @http::get("https://httpbin.org/get", {header_name: '!!Header value!!'})
-$.print(request)

--- a/test.spwn
+++ b/test.spwn
@@ -1,0 +1,2 @@
+let request = @http::get("https://httpbin.org/get", {header_name: '!!Header value!!'})
+$.print(request)


### PR DESCRIPTION
header values where being created with .to_str() which added quotation marks on either side. just made a small fix for that,