### PR TITLE
Removed --release from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Let it compile and you're good to go
 2. Unzip the .zip file
 3. Install rust if you haven't already
 4. Open the unzipped folder in the terminal
-5. Run `cargo build --release`
+5. Run `cargo build`
 6. Compiled binary is placed in `target/release`
 
 ## Using SPWN - Setup


### PR DESCRIPTION
`cargo build --release` gives the following error, so I guess we can remove `--release` from the readme
```rs
error: cannot find macro `include_dir` in this scope
    --> compiler\src\builtins.rs:31:28
     |
31   | const STANDARD_LIBS: Dir = include_dir!("../libraries");
     |                            ^^^^^^^^^^^ help: a macro with a similar name exists: `include_str`
     |

warning: `parser` (lib) generated 5 warnings
error: could not compile `compiler` due to previous error
warning: build failed, waiting for other jobs to finish...
error: build failed
```