### PR TITLE
Add hex, binary, and octal literals

### DIFF
--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -163,8 +163,14 @@ pub enum Token {
     #[regex(r"([a-zA-Z_][a-zA-Z0-9_]*)|\$")]
     Symbol,
 
-    #[regex(r"[0-9][0-9_]*(\.[0-9_]+)?")]
+    #[regex(r"([0-9][0-9_]*(\.[0-9_]+)?)")]
     Number,
+
+    #[regex("0b[01](_?[01]+)*")]
+    BinaryLiteral,
+
+    #[regex("0x[a-fA-F0-9](_?[a-fA-F0-9]+)*")]
+    HexLiteral,
 
     #[regex(r#"[a-z]?"(?:\\.|[^\\"])*"|'(?:\\.|[^\\'])*'"#)]
     StringLiteral,
@@ -306,7 +312,7 @@ impl Token {
                 "operator"
             }
             Symbol => "identifier",
-            Number => "number literal",
+            Number | BinaryLiteral | HexLiteral => "number literal",
             StringLiteral => "string literal",
             True | False => "boolean literal",
             Id => "ID literal",
@@ -2148,6 +2154,30 @@ fn parse_variable(
                     return Err(SyntaxError::SyntaxError {
                         message: format!("Error when parsing number: {}", err),
 
+                        pos: tokens.position(),
+                        file: notes.file.clone(),
+                    });
+                }
+            })
+        }
+        Some(Token::BinaryLiteral) => {
+            ast::ValueBody::Number(match i64::from_str_radix(&tokens.slice().replace("_", "").replace("0b", ""), 2) {
+                Ok(n) => n as f64, // its a valid number
+                Err(err) => {
+                    return Err(SyntaxError::SyntaxError {
+                        message: format!("Error when parsing number: {}", err),
+                        pos: tokens.position(),
+                        file: notes.file.clone(),
+                    });
+                }
+            })
+        }
+        Some(Token::HexLiteral) => {
+            ast::ValueBody::Number(match i64::from_str_radix(&tokens.slice().replace("_", "").replace("0x", ""), 16) {
+                Ok(n) => n as f64, // its a valid number
+                Err(err) => {
+                    return Err(SyntaxError::SyntaxError {
+                        message: format!("Error when parsing number: {}", err),
                         pos: tokens.position(),
                         file: notes.file.clone(),
                     });

--- a/test/test.spwn
+++ b/test/test.spwn
@@ -1,10 +1,12 @@
 #[no_level]
 
 uwu = 0b1010 // 10
-owo = 0x0a0a // 2570
+owo = 0x0a   // 10
+qwq = 0o12   // 10
 
 $.print(uwu)
 $.print(owo)
+$.print(qwq)
 
 // list = ["hello", " ", "world", "!"]
 

--- a/test/test.spwn
+++ b/test/test.spwn
@@ -1,7 +1,11 @@
 #[no_level]
 
+uwu = 0b1010 // 10
+owo = 0x0a0a // 2570
 
+$.print(uwu)
+$.print(owo)
 
-list = ["hello", " ", "world", "!"]
+// list = ["hello", " ", "world", "!"]
 
-$.print(list.reduce((a, b, c) => a + b))
+// $.print(list.reduce((a, b, c) => a + b))


### PR DESCRIPTION
This addition works at a compiler level, it always parses to a spwn `Number` during compile time