### PR TITLE
Add new string flag 'u'

### DIFF
--- a/compiler/src/value.rs
+++ b/compiler/src/value.rs
@@ -1037,11 +1037,6 @@ pub fn convert_type(
         (Value::Number(n), type_id!(number)) => Value::Number(*n),
         (Value::Number(n), type_id!(bool)) => Value::Bool(*n != 0.0),
 
-            
-        
-
-        
-
         (Value::Group(g), type_id!(number)) => Value::Number(match g.id {
             Id::Specific(n) => n as f64,
             _ => return Err(RuntimeError::CustomError(create_error(
@@ -1109,17 +1104,57 @@ pub fn convert_type(
 
     
         (Value::Str(s), type_id!(number)) => {
-            let out: std::result::Result<f64, _> = s.parse();
-            match out {
-                Ok(n) => Value::Number(n),
+            match &s[..2] {
+                "0x" => {
+                    if let Ok(out) = i64::from_str_radix(&s.replace("0x", ""), 16) {
+                        return Ok(Value::Number(out as f64))
+                    } else {
+                        return Err(RuntimeError::CustomError(create_error(
+                            info.clone(),
+                            &format!("Cannot convert string '{}' to @number", s),
+                            &[],
+                            None,
+                        ))) 
+                    }
+                }
+                "0b" => {
+                    if let Ok(out) = i64::from_str_radix(&s.replace("0b", ""), 2) {
+                        return Ok(Value::Number(out as f64))
+                    } else {
+                        return Err(RuntimeError::CustomError(create_error(
+                            info.clone(),
+                            &format!("Cannot convert string '{}' to @number", s),
+                            &[],
+                            None,
+                        ))) 
+                    }
+                }
+                "0o" => {
+                    if let Ok(out) = i64::from_str_radix(&s.replace("0o", ""), 8) {
+                        return Ok(Value::Number(out as f64))
+                    } else {
+                        return Err(RuntimeError::CustomError(create_error(
+                            info.clone(),
+                            &format!("Cannot convert string '{}' to @number", s),
+                            &[],
+                            None,
+                        ))) 
+                    }
+                }
                 _ => {
-                    
-                    return Err(RuntimeError::CustomError(create_error(
-                        info.clone(),
-                        &format!("Cannot convert string '{}' to @number", s),
-                        &[],
-                        None,
-                    ))) 
+                    let out: std::result::Result<f64, _> = s.parse();
+                    match out {
+                        Ok(n) => Value::Number(n),
+                        _ => {
+                            
+                            return Err(RuntimeError::CustomError(create_error(
+                                info.clone(),
+                                &format!("Cannot convert string '{}' to @number", s),
+                                &[],
+                                None,
+                            ))) 
+                        }
+                    }
                 }
             }
         },

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -144,6 +144,7 @@ pub struct StrInner {
 #[derive(Clone, PartialEq, Debug)]
 pub enum StringFlags {
     Raw,
+    Unindent
 }
 
 #[derive(Clone, Copy, PartialEq, Debug)]

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -1886,6 +1886,14 @@ pub fn str_content(
 
             out_str = out_str.replace("\t", "    ");
 
+            if !out_str.starts_with('\n') {
+                return Err(SyntaxError::SyntaxError {
+                    message: "Strings with the u flag must start with a newline".into(),
+                    pos: tokens.position(),
+                    file: notes.file.clone(),
+                })
+            }
+
             let mut lines = out_str.lines();
             lines.next();
 

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -1859,8 +1859,10 @@ pub fn str_content(
 
             out.1 = StringFlags::Unindent.into();
 
+            let mut out_str = String::new(); 
+
             while let Some(c) = chars.next() {
-                out.0.push(if c == '\\' {
+                out_str.push(if c == '\\' {
                     match chars.next() {
                         Some('n') => '\n',
                         Some('r') => '\r',
@@ -1882,7 +1884,18 @@ pub fn str_content(
                 });
             }
 
-            out.0 = out.0.trim().to_string();
+            out_str = out_str.replace("\t", "    ");
+
+            let mut lines = out_str.lines();
+            lines.next();
+
+            let min_indent = lines.clone().map(|line| line.chars().take_while(|a| *a == ' ').count()).min().unwrap_or_else(|| unreachable!());
+
+            while let Some(line) = lines.next() {
+                if line.chars().take(min_indent).all(|c| c == ' ') {
+                    out.0 += &format!("{}\n", &line[min_indent..]);
+                }
+            }
         }
         _ => {
             return Err(SyntaxError::SyntaxError {

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -1894,8 +1894,7 @@ pub fn str_content(
                 })
             }
 
-            let mut lines = out_str.lines();
-            lines.next();
+            let mut lines = out_str.lines().filter(|line| line.len() > 0);
 
             let min_indent = lines.clone().map(|line| line.chars().take_while(|a| *a == ' ').count()).min().unwrap_or_else(|| unreachable!());
 

--- a/test/test.spwn
+++ b/test/test.spwn
@@ -4,7 +4,9 @@ uwu = "0b1010" as @number // 10
 owo = "0x0a" as @number   // 10
 qwq = "0o12" as @number   // 10
 
-foo = u"foo
+foo = u"
+
+    foo
         bar
     baz
 "

--- a/test/test.spwn
+++ b/test/test.spwn
@@ -1,12 +1,21 @@
 #[no_level]
 
-uwu = 0b1010 // 10
-owo = 0x0a   // 10
-qwq = 0o12   // 10
+uwu = "0b1010" as @number // 10
+owo = "0x0a" as @number   // 10
+qwq = "0o12" as @number   // 10
 
-$.print(uwu)
-$.print(owo)
-$.print(qwq)
+foo = u"
+foo
+bar
+baz
+"
+
+$.print(foo, " ", foo.type)
+
+$.print(uwu, " ", uwu.type)
+$.print(owo, " ", owo.type)
+$.print(qwq, " ", qwq.type)
+
 
 // list = ["hello", " ", "world", "!"]
 

--- a/test/test.spwn
+++ b/test/test.spwn
@@ -4,8 +4,7 @@ uwu = "0b1010" as @number // 10
 owo = "0x0a" as @number   // 10
 qwq = "0o12" as @number   // 10
 
-foo = u"
-    foo
+foo = u"foo
         bar
     baz
 "

--- a/test/test.spwn
+++ b/test/test.spwn
@@ -5,9 +5,9 @@ owo = "0x0a" as @number   // 10
 qwq = "0o12" as @number   // 10
 
 foo = u"
-foo
-bar
-baz
+    foo
+        bar
+    baz
 "
 
 $.print(foo, " ", foo.type)


### PR DESCRIPTION
## This flag removes newlines from the start and end of strings:

```rs
foo = u"
foo
bar
baz
"

$.print(foo)
```
Outputs:
```
foo
bar
baz
```