### PR TITLE
@array::sort, @array::sorted and @array::_partition fixes

### DIFF
--- a/libraries/std/array.spwn
+++ b/libraries/std/array.spwn
@@ -383,36 +383,19 @@ $.assert(arr2.sum(a => a.length) == 9)
         return result
     },
 
-    sort: #[desc("Sorts array in-place") example("
-let arr = [5, 1, 5, 3, 2]
-arr.sort()
-$.assert(arr == [1, 2, 3, 5, 5])
+    sort: #[desc("Returns a sorted verison of the array") example(u"
+        let arr = [5, 1, 5, 3, 2]
+        $.assert(arr.sort() == [1, 2, 3, 5, 5])
 
-let arr = [5, 1, 5, 3, 2]
-arr.sort(begin = 2, end = 4)
-$.assert(arr == [5, 1, 2, 3, 5])
-
-let arr = [5, 1, 5, 3, 2]
-arr.sort(comp = (a, b) => a >= b)
-$.assert(arr == [5, 5, 3, 2, 1])
+        let arr = [5, 1, 5, 3, 2]
+        $.assert(arr.sort(comp = (a, b) => a >= b) == [5, 5, 3, 2, 1])
     ")]
-    (self, begin: @number = 0, end: @number = -1, comp: (_, _) -> @bool = (a, b) => a <= b) -> @NULL {
-
-        // when end == -1, that means the end of the array, but comparing to -1 doesnt work so switch it back to legnth - 1
-        let new_end = end
-        if end == -1 {
-            new_end = self.length - 1
-        }
-
-        // uses quick sort
-        // no type checking becuase theoretically this can sort anything if it hasthe right comparator
-        // if sort was overloaded we could have two seperate implementations
-        if begin < new_end {
-            let q = self._partition(low = begin, high = new_end, comp = comp)
-
-            self.sort(begin = begin, end = q-1, comp = comp)
-            self.sort(begin = q+1, end = new_end, comp = comp)
-        }
+    (self, comp: (_,_) -> @bool = (a, b) => a <= b) {
+        let array = self
+        if array.length == 0 { return [] }
+        pivot = array.pop()
+        [ truthy, falsy ] = array.partition(i => comp(i,pivot))
+        return truthy.sort(comp = comp) + [pivot] + falsy.sort(comp = comp) // heskell quicksort goes brr
     },
 
     sorted: #[desc("Returns a sorted verison of the array") example("

--- a/libraries/std/array.spwn
+++ b/libraries/std/array.spwn
@@ -383,22 +383,6 @@ $.assert(arr2.sum(a => a.length) == 9)
         return result
     },
 
-    _partition: #[desc("Private function needed for .sort()")]
-    (self, low: @number, high: @number, comp: (_, _) -> @bool = (a, b) => a <= b) {
-        pivot = self[high]
-        let i = low - 1
-
-        for j in low..high {
-            if comp(self[j], pivot) {
-                i += 1
-                self[i] <=> self[j]
-            }
-        }
-
-        self[i+1] <=> self[high]
-        return i + 1
-    },
-
     sort: #[desc("Sorts array in-place") example("
 let arr = [5, 1, 5, 3, 2]
 arr.sort()

--- a/libraries/std/array.spwn
+++ b/libraries/std/array.spwn
@@ -390,11 +390,17 @@ $.assert(arr2.sum(a => a.length) == 9)
         let arr = [5, 1, 5, 3, 2]
         $.assert(arr.sort(comp = (a, b) => a >= b) == [5, 5, 3, 2, 1])
     ")]
-    (self, comp: (_,_) -> @bool = (a, b) => a <= b) {
+    (self, comp: (_,_) -> @bool | @number = (a, b) => a <= b) -> @array {
         let array = self
         if array.length == 0 { return [] }
         pivot = array.pop()
-        [ truthy, falsy ] = array.partition(i => comp(i,pivot))
+        [ truthy, falsy ] = array.partition((i){
+            result = comp(i,pivot)
+            return switch result {
+                @bool: result,
+                @number: result < 0,
+            }
+        })
         return truthy.sort(comp = comp) + [pivot] + falsy.sort(comp = comp) // heskell quicksort goes brr
     },
 

--- a/libraries/std/array.spwn
+++ b/libraries/std/array.spwn
@@ -398,17 +398,18 @@ $.assert(arr2.sum(a => a.length) == 9)
         return truthy.sort(comp = comp) + [pivot] + falsy.sort(comp = comp) // heskell quicksort goes brr
     },
 
-    sorted: #[desc("Returns a sorted verison of the array") example("
-arr = [5, 1, 5, 3, 2]
-$.assert(arr.sorted() == [1, 2, 3, 5, 5])
-$.assert(arr.sorted(begin = 2, end = 4) == [5, 1, 2, 3, 5])
-$.assert(arr.sorted(comp = (a, b) => a >= b) == [5, 5, 3, 2, 1])
+    sorted: #[desc("Returns true if the array is sorted.") example(u"
+        $.assert([5, 1, 5, 3, 2].sorted() == false)
+        $.assert([1, 2, 3, 5, 5].sorted() == true)
+        $.assert([5, 5, 3, 2, 1].sorted(comp = (a, b) => a >= b) == true)
     ")]
-    (self, begin: @number = 0, end: @number = -1, comp: (_, _) -> @bool = (a, b) => a <= b) -> @array {
-        let new_arr = self
-        new_arr.sort(begin,end,comp)
-
-        return new_arr
+    (self, comp: (_, _) -> @bool = (a, b) => a <= b) -> @bool {
+        for i in 1..self.length {
+            if !comp(self[i-1], self[i]) {
+                return false
+            }
+        }
+        return true
     },
 
     shift: #[desc("Removes the first index from the array and returns it.") example("


### PR DESCRIPTION
`sort` makes more sense to not be in-place
`sorted` sounds like something that should return a boolean
`_partition` is not needed since `partition` is a thing 😎