### PR TITLE
Fixed the ID regex

### DIFF
--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -184,7 +184,7 @@ pub enum Token {
     #[token("false")]
     False,
 
-    #[regex(r"[0-9?]+[gbci]")]
+    #[regex(r"([0-9]+|\?)[gbci]")]
     Id,
 
     //TERMINATORS


### PR DESCRIPTION
Previously you could do `420?69????????g` and it would be considered a valid ID by the parser, now it will only allow `?g` or `1g`