### PR TITLE
Added default value to @array::reduce

### DIFF
--- a/libraries/std/array.spwn
+++ b/libraries/std/array.spwn
@@ -330,10 +330,14 @@ $.assert(arr.filter(el => el > 3) == [4, 5])
 arr = [1, 2, 3, 4, 5]
 sum = arr.reduce((acum, el) => acum + el)
 $.assert(sum == 15)
+
+arr = [5, 1, 5, 3, 2]
+product = arr.reduce((acum, el) => acum * el, 1)
+$.assert(product == 150)
     ")]
-    (self, cb: (_, _) -> _) -> _ {
-        let acum = self[0];
-        for iter in 1..self.length {
+    (self, cb: (_, _) -> _, default = 0) -> _ {
+        let acum = default;
+        for iter in 0..self.length {
             acum = cb(acum, self[iter]);
         }
         return acum;


### PR DESCRIPTION
It's better to have a default value over using the first value as the default one, not always the type of the output should be the same as the first item, therefore this gives more control.