### PR TITLE
Fixed u stringflag not allowing spaces on the first line

### DIFF
--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -1982,7 +1982,10 @@ pub fn str_content(
                 });
             }
 
-            out_str = out_str.replace("\t", "    ");
+            out_str = out_str
+                .replace("\t", "    ")
+                .trim_start_matches(' ')
+                .to_string();
 
             if !out_str.starts_with('\n') {
                 return Err(SyntaxError::SyntaxError {


### PR DESCRIPTION
```rs
string = u" 
  sussy
  baka
"
```
giving the `Strings with the u flag must start with a newline` error with no apparent reason