### PR TITLE
Check if the Object is empty before adding it to the level

### DIFF
--- a/compiler/src/builtins.rs
+++ b/compiler/src/builtins.rs
@@ -997,7 +997,7 @@ $.add(obj {
         };
 
         if obj.is_empty() {
-            // return Ok(());
+            return Ok(());
         }
 
         let mut ignore_context = false;

--- a/compiler/src/builtins.rs
+++ b/compiler/src/builtins.rs
@@ -996,6 +996,10 @@ $.add(obj {
             })
         };
 
+        if obj.is_empty() {
+            // return Ok(());
+        }
+
         let mut ignore_context = false;
         if arguments.len() == 2 {
             match globals.stored_values[arguments[1]].clone() {


### PR DESCRIPTION
consider squashing this shit

it's funny how previously `$.add(obj{})` added an object with only `57,1001,;`