### PR TITLE
Add Nix expression

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ spwn-web/ansi_up.js
 pckp_libraries
 .pckp_tmp
 test/flow_level
+result/

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,22 @@
+{ pkgs ? import <nixpkgs> {}, lib ? pkgs.lib }:
+
+{
+  spwn = pkgs.rustPlatform.buildRustPackage {
+    name = "spwn";
+    src = ./.;
+    nativeBuildInputs = with pkgs; [
+      pkg-config
+    ];
+    buildInputs = with pkgs; [
+      openssl
+    ];
+    cargoLock = {
+      lockFile = ./Cargo.lock;
+    };
+
+    meta = with lib; {
+      description = "A language for Geometry Dash triggers";
+      license = licenses.mit;
+    };
+  };
+}


### PR DESCRIPTION
Hi, you probably never asked for this, but I decided to invest time into writing a Nix expression for this software.

The main advantage of [Nix](https://nixos.org/nix) is that it makes sure that builds can be reproduced anywhere, anytime.
People who use Nix(OS) will be able to painlessly install/import spwn into their configs.

You shouldn't have to worry about maintaining yet another language. It's extremely unlikely for this Nix expression to break, unless you move or delete `Cargo.lock`. If the Nix expression *does* happen to break, feel free to @ me.

Have a nice day.

PS: [This video of yours made me aware of this repository](https://youtu.be/cQyNar6rgW8)

---
### Checklist
- [X] `nix-build` successfully compiles the project
- [X] `result/bin/spwn` (build output) successfully compiles `.spwn` files
### Host machine config
`nix-shell -p nix-info --run "nix-info -m"`
 - system: `"x86_64-linux"`
 - host os: `Linux 5.17.7-zen1-1-zen, Arch Linux, noversion, rolling`
 - multi-user?: `yes`
 - sandbox: `yes`
 - version: `nix-env (Nix) 2.7.0`
 - channels(root): `"nixpkgs"`
 - nixpkgs: `/nix/var/nix/profiles/per-user/root/channels/nixpkgs`