### PR TITLE
Add Clippy to the Github Workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -5,6 +5,8 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+  workflow_dispatch:
+    
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,6 +19,8 @@ jobs:
         run: cargo build --release --verbose
       - name: Run tests
         run: cargo test --verbose --profile test
+      - name: Run clippy
+        run: cargo clippy --all --verbose
       # - name: Install rust WASM
       #   run: rustup target add wasm32-unknown-unknown
       # - name: Test if the code will build to a WASM binary


### PR DESCRIPTION
Turns on automatic checks with Clippy on the workflow that builds the project. Clippy is the standard linting tool for rust and shows more warnings than just the warnings from building as well as forming recommendations for code.

This also enables the option for workflows to be manually run