### PR TITLE
Fixed compile issue on Mac, Linux, and Android

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -61,7 +61,6 @@ pub struct BuildSettings {
     #[arg(short = 'f', long)]
     pub save_file: Option<PathBuf>,
 
-    #[cfg(target_os = "windows")]
     #[arg(short = 'e', long)]
     pub live_editor: bool,
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -61,6 +61,7 @@ pub struct BuildSettings {
     #[arg(short = 'f', long)]
     pub save_file: Option<PathBuf>,
 
+    #[cfg(target_os = "windows")]
     #[arg(short = 'e', long)]
     pub live_editor: bool,
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,6 +4,7 @@ use thiserror::Error;
 
 use crate::doc::error::DocError;
 use crate::gd::error::LevelError;
+#[cfg(target_os = "windows")]
 use crate::liveeditor::WebSocketError;
 use crate::util::error::ErrorReport;
 
@@ -23,6 +24,7 @@ pub enum SpwnError {
     #[error("{0}")]
     DocError(#[from] DocError),
 
+    #[cfg(target_os = "windows")]
     #[error("{0}")]
     WebSocketError(#[from] WebSocketError),
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@ use clap::Parser as _;
 use cli::{BuildSettings, DocSettings};
 use colored::Colorize;
 use doc::DocCompiler;
+use error::SpwnError;
 use gd::gd_object::{GdObject, TriggerObject};
 use interpreting::vm::Vm;
 use lasso::Rodeo;
@@ -44,7 +45,7 @@ use crate::parsing::parser::Parser;
 use crate::sources::{SpwnSource, TypeDefMap};
 use crate::util::interner::Interner;
 use crate::util::spinner::Spinner;
-use crate::util::{hyperlink, BasicError, HexColorize};
+use crate::util::{hyperlink, HexColorize};
 
 mod cli;
 mod compiling;
@@ -74,7 +75,7 @@ struct SpwnOutput {
     pub id_counters: [u16; 4],
 }
 
-fn main() -> Result<(), Box<dyn Error>> {
+fn main() -> Result<(), SpwnError> {
     assert_eq!(4, std::mem::size_of::<OptOpcode>());
 
     let args = Arguments::parse();
@@ -110,7 +111,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 } else if cfg!(target_os = "android") {
                     PathBuf::from("/data/data/com.robtopx.geometryjump/CCLocalLevels.dat")
                 } else {
-                    return Err(BasicError("Unsupported operating system").into());
+                    return Err(SpwnError::UsuppportedOS);
                 })
             } else {
                 None
@@ -282,9 +283,9 @@ fn run_spwn(
     file: PathBuf,
     settings: &BuildSettings,
     spinner: &mut Spinner,
-) -> Result<SpwnOutput, Box<dyn Error>> {
+) -> Result<SpwnOutput, SpwnError> {
     let src = Rc::new(SpwnSource::File(file));
-    let code = src.read().ok_or(BasicError("Failed to read SPWN file"))?;
+    let code = src.read().ok_or(SpwnError::FailedToReadSpwnFile)?;
 
     let interner = Interner::new();
 
@@ -369,29 +370,20 @@ fn run_spwn(
     })
 }
 
-fn generate_doc(settings: &DocSettings, spinner: &mut Spinner) -> Result<(), Box<dyn Error>> {
-    let file: PathBuf = if let Some(file) = &settings.file {
+fn generate_doc(settings: &DocSettings, spinner: &mut Spinner) -> Result<(), SpwnError> {
+    let root: PathBuf = if let Some(file) = &settings.file {
         file.into()
     } else if let Some(lib) = &settings.lib {
         let p: PathBuf = lib.into();
 
         if p.is_file() {
-            Err(BasicError(
-                "`--lib`/`-l` argument expected a library, found file",
-            ))?;
+            Err(SpwnError::DocExpectedLibrary)?;
         }
 
         p.join("lib.spwn")
     } else {
         unreachable!("BUG: no file/lib specified")
     };
-
-    let src = Rc::new(SpwnSource::File(file));
-    let code = src.read().ok_or(BasicError("Failed to read SPWN file"))?;
-
-    let interner = Interner::new();
-
-    let mut parser: Parser<'_> = Parser::new(&code, Rc::clone(&src), interner.clone());
 
     spinner.start(format!(
         "{:20}",
@@ -400,12 +392,11 @@ fn generate_doc(settings: &DocSettings, spinner: &mut Spinner) -> Result<(), Box
             .bold()
     ));
 
-    let ast = parser.parse().map_err(|e| e.to_report())?;
-
-    let compiler = DocCompiler::new(settings, src, interner);
-    //compiler.compile(ast)?;
+    let mut compiler = DocCompiler::new(settings, root);
+    compiler.compile()?;
 
     spinner.complete(None);
 
     Ok(())
 }
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,6 @@ use clap::Parser as _;
 use cli::{BuildSettings, DocSettings};
 use colored::Colorize;
 use doc::DocCompiler;
-use error::SpwnError;
 use gd::gd_object::{GdObject, TriggerObject};
 use interpreting::vm::Vm;
 use lasso::Rodeo;
@@ -45,7 +44,7 @@ use crate::parsing::parser::Parser;
 use crate::sources::{SpwnSource, TypeDefMap};
 use crate::util::interner::Interner;
 use crate::util::spinner::Spinner;
-use crate::util::{hyperlink, HexColorize};
+use crate::util::{hyperlink, BasicError, HexColorize};
 
 mod cli;
 mod compiling;
@@ -75,7 +74,7 @@ struct SpwnOutput {
     pub id_counters: [u16; 4],
 }
 
-fn main() -> Result<(), SpwnError> {
+fn main() -> Result<(), Box<dyn Error>> {
     assert_eq!(4, std::mem::size_of::<OptOpcode>());
 
     let args = Arguments::parse();
@@ -91,11 +90,10 @@ fn main() -> Result<(), SpwnError> {
 
     match args.command {
         Command::Build { file, settings } => {
-            let is_live_editor = if cfg!(target_os = "windows") {
-                settings.live_editor
-            } else {
-                false
-            };
+            #[cfg(target_os = "windows")]
+            let is_live_editor = settings.live_editor;
+            #[cfg(not(target_os = "windows"))]
+            let is_live_editor = false;
 
             let gd_path = if !(settings.no_level || is_live_editor) {
                 Some(if let Some(ref sf) = settings.save_file {
@@ -112,7 +110,7 @@ fn main() -> Result<(), SpwnError> {
                 } else if cfg!(target_os = "android") {
                     PathBuf::from("/data/data/com.robtopx.geometryjump/CCLocalLevels.dat")
                 } else {
-                    return Err(SpwnError::UsuppportedOS);
+                    return Err(BasicError("Unsupported operating system").into());
                 })
             } else {
                 None
@@ -284,9 +282,9 @@ fn run_spwn(
     file: PathBuf,
     settings: &BuildSettings,
     spinner: &mut Spinner,
-) -> Result<SpwnOutput, SpwnError> {
+) -> Result<SpwnOutput, Box<dyn Error>> {
     let src = Rc::new(SpwnSource::File(file));
-    let code = src.read().ok_or(SpwnError::FailedToReadSpwnFile)?;
+    let code = src.read().ok_or(BasicError("Failed to read SPWN file"))?;
 
     let interner = Interner::new();
 
@@ -371,20 +369,29 @@ fn run_spwn(
     })
 }
 
-fn generate_doc(settings: &DocSettings, spinner: &mut Spinner) -> Result<(), SpwnError> {
-    let root: PathBuf = if let Some(file) = &settings.file {
+fn generate_doc(settings: &DocSettings, spinner: &mut Spinner) -> Result<(), Box<dyn Error>> {
+    let file: PathBuf = if let Some(file) = &settings.file {
         file.into()
     } else if let Some(lib) = &settings.lib {
         let p: PathBuf = lib.into();
 
         if p.is_file() {
-            Err(SpwnError::DocExpectedLibrary)?;
+            Err(BasicError(
+                "`--lib`/`-l` argument expected a library, found file",
+            ))?;
         }
 
         p.join("lib.spwn")
     } else {
         unreachable!("BUG: no file/lib specified")
     };
+
+    let src = Rc::new(SpwnSource::File(file));
+    let code = src.read().ok_or(BasicError("Failed to read SPWN file"))?;
+
+    let interner = Interner::new();
+
+    let mut parser: Parser<'_> = Parser::new(&code, Rc::clone(&src), interner.clone());
 
     spinner.start(format!(
         "{:20}",
@@ -393,11 +400,12 @@ fn generate_doc(settings: &DocSettings, spinner: &mut Spinner) -> Result<(), Spw
             .bold()
     ));
 
-    let mut compiler = DocCompiler::new(settings, root);
-    compiler.compile()?;
+    let ast = parser.parse().map_err(|e| e.to_report())?;
+
+    let compiler = DocCompiler::new(settings, src, interner);
+    //compiler.compile(ast)?;
 
     spinner.complete(None);
 
     Ok(())
 }
-

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@ use clap::Parser as _;
 use cli::{BuildSettings, DocSettings};
 use colored::Colorize;
 use doc::DocCompiler;
+use error::SpwnError;
 use gd::gd_object::{GdObject, TriggerObject};
 use interpreting::vm::Vm;
 use lasso::Rodeo;
@@ -44,7 +45,7 @@ use crate::parsing::parser::Parser;
 use crate::sources::{SpwnSource, TypeDefMap};
 use crate::util::interner::Interner;
 use crate::util::spinner::Spinner;
-use crate::util::{hyperlink, BasicError, HexColorize};
+use crate::util::{hyperlink, HexColorize};
 
 mod cli;
 mod compiling;
@@ -74,7 +75,7 @@ struct SpwnOutput {
     pub id_counters: [u16; 4],
 }
 
-fn main() -> Result<(), Box<dyn Error>> {
+fn main() -> Result<(), SpwnError> {
     assert_eq!(4, std::mem::size_of::<OptOpcode>());
 
     let args = Arguments::parse();
@@ -111,7 +112,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 } else if cfg!(target_os = "android") {
                     PathBuf::from("/data/data/com.robtopx.geometryjump/CCLocalLevels.dat")
                 } else {
-                    return Err(BasicError("Unsupported operating system").into());
+                    return Err(SpwnError::UsuppportedOS);
                 })
             } else {
                 None
@@ -283,9 +284,9 @@ fn run_spwn(
     file: PathBuf,
     settings: &BuildSettings,
     spinner: &mut Spinner,
-) -> Result<SpwnOutput, Box<dyn Error>> {
+) -> Result<SpwnOutput, SpwnError> {
     let src = Rc::new(SpwnSource::File(file));
-    let code = src.read().ok_or(BasicError("Failed to read SPWN file"))?;
+    let code = src.read().ok_or(SpwnError::FailedToReadSpwnFile)?;
 
     let interner = Interner::new();
 
@@ -370,29 +371,20 @@ fn run_spwn(
     })
 }
 
-fn generate_doc(settings: &DocSettings, spinner: &mut Spinner) -> Result<(), Box<dyn Error>> {
-    let file: PathBuf = if let Some(file) = &settings.file {
+fn generate_doc(settings: &DocSettings, spinner: &mut Spinner) -> Result<(), SpwnError> {
+    let root: PathBuf = if let Some(file) = &settings.file {
         file.into()
     } else if let Some(lib) = &settings.lib {
         let p: PathBuf = lib.into();
 
         if p.is_file() {
-            Err(BasicError(
-                "`--lib`/`-l` argument expected a library, found file",
-            ))?;
+            Err(SpwnError::DocExpectedLibrary)?;
         }
 
         p.join("lib.spwn")
     } else {
         unreachable!("BUG: no file/lib specified")
     };
-
-    let src = Rc::new(SpwnSource::File(file));
-    let code = src.read().ok_or(BasicError("Failed to read SPWN file"))?;
-
-    let interner = Interner::new();
-
-    let mut parser: Parser<'_> = Parser::new(&code, Rc::clone(&src), interner.clone());
 
     spinner.start(format!(
         "{:20}",
@@ -401,12 +393,11 @@ fn generate_doc(settings: &DocSettings, spinner: &mut Spinner) -> Result<(), Box
             .bold()
     ));
 
-    let ast = parser.parse().map_err(|e| e.to_report())?;
-
-    let compiler = DocCompiler::new(settings, src, interner);
-    //compiler.compile(ast)?;
+    let mut compiler = DocCompiler::new(settings, root);
+    compiler.compile()?;
 
     spinner.complete(None);
 
     Ok(())
 }
+


### PR DESCRIPTION
Due to the `live_editor` member of the `BuildSettings` struct only compiling in on Windows, other platforms would simply error upon attempting to access it.