### PR TITLE
Suggest install natively from src

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Let it compile and you're good to go.
 - Linux: Right click the folder and press `Open in Terminal`.
 6. Run:
   ```sh
-  cargo install . --config 'build.rustflags="-C target-cpu=native"'
+  cargo install --path . --config 'build.rustflags="-C target-cpu=native"'
   ```
 
 ## Using SPWN

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ cargo install spwn
 
 Let it compile and you're good to go.
 
-### Compiling from source
+### Installing from source
 
 1. [Download](https://github.com/Spu7Nix/SPWN-language/archive/refs/heads/master.zip) the source code from this repository.
 2. Unzip the .zip file.
@@ -124,8 +124,10 @@ Let it compile and you're good to go.
 - Windows: Right click the folder and press `Open command window here`.
 - Mac: Open `Terminal.app` in the `Utilities` folder in the `Applications` folder, then drag and drop the folder onto the terminal window and press enter.
 - Linux: Right click the folder and press `Open in Terminal`.
-6. Run `cargo build --release`.
-7. Compiled binary is placed in the `target/release` directory.
+6. Run:
+  ```sh
+  cargo install . --config 'build.rustflags="-C target-cpu=native"'
+  ```
 
 ## Using SPWN
 


### PR DESCRIPTION
> [!warning]
> I haven't (yet) tested if the cmd works!

This is more convenient than getting the executable from `target/`. As a bonus, it compiles to the host-machine native CPU micro-architecture, which is what Gentoo, and Dalvik/A.R.T., do